### PR TITLE
Update README + test on Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
 
 python:
+ - 3.6
+ - 3.5
  - 3.4
- - 3.5-dev
 
 # Use container-based infrastructure
 sudo: false

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is really raw software and it's probably not suitable for use by anyone
 other than me. I just wanted it on Github so I can include it in
 `pip` requirements files.
 
-##Motivation and examples
+## Motivation and examples
 
 Say you start out with a series of strings, like:
 
@@ -22,7 +22,7 @@ something new and interesting:
     >>> from random import sample, randrange
     >>> first, second = sample(parts, 2)
     >>> result = first[:randrange(len(first))] + second[randrange(len(second)):]
-    >>> print(result) 
+    >>> print(result)
     once upon a time and the best of times, it was the worst of times
 
 The resulting string is amusing, but there's no way to tell *which* strings
@@ -66,7 +66,7 @@ operators implemented with special methods like `__add__`, `__getitem__` and
     >>> print(repl.parents)
     ('it was the best of times, it was the worst of times',)
 
-##Keeping track of tags
+## Keeping track of tags
 
 The `treestr` also allows you to keep track of metadata on a string through a
 mechanism called `tags`. The `tags` attribute on a `treestr` is a Python
@@ -100,7 +100,7 @@ your remixed string:
 Easy peasy, and if you're just using regular string methods, you don't have to
 change any of your code!
 
-##The strange case of `.join()`
+## The strange case of `.join()`
 
 You can mix and match regular `str` objects with `treestr` objects, no problem.
 But be aware of `.join()`: if you want it to work properly, you need to call
@@ -115,7 +115,7 @@ regular `str`):
     >>> print(result)
     once  times
 
-##Installation
+## Installation
 
 Install from Github with `pip` like so:
 
@@ -124,12 +124,12 @@ Install from Github with `pip` like so:
 Not putting this on PyPI until I'm convinced it actually has utility for anyone
 other than me.
 
-##Compatibility
+## Compatibility
 
 Only tested with Python 3.4. (There's some stuff in Python 3.4 that makes it
 easier to subtype `str` and I'm too lazy to backport everything.)
 
-##License
+## License
 
 Copyright (c) 2015, Allison Parrish
 All rights reserved.

--- a/README.md
+++ b/README.md
@@ -12,18 +12,22 @@ other than me. I just wanted it on Github so I can include it in
 
 Say you start out with a series of strings, like:
 
-    >>> parts = ["it was the best of times, it was the worst of times",
-    ...     "happy families are all alike",
-    ...     "once upon a time and a very good time it was"]
+```python
+>>> parts = ["it was the best of times, it was the worst of times",
+...     "happy families are all alike",
+...     "once upon a time and a very good time it was"]
+```
 
 ... and then you do some random recombinations of these strings to make
 something new and interesting:
 
-    >>> from random import sample, randrange
-    >>> first, second = sample(parts, 2)
-    >>> result = first[:randrange(len(first))] + second[randrange(len(second)):]
-    >>> print(result)
-    once upon a time and the best of times, it was the worst of times
+```python
+>>> from random import sample, randrange
+>>> first, second = sample(parts, 2)
+>>> result = first[:randrange(len(first))] + second[randrange(len(second)):]
+>>> print(result)
+once upon a time and the best of times, it was the worst of times
+```
 
 The resulting string is amusing, but there's no way to tell *which* strings
 from the original list were the ultimate sources of the string's component
@@ -35,20 +39,22 @@ entirely new abstraction just to keep this metadata with the string.
 
 To solve this problem, I give you... the `treestr`.
 
-    >>> from treestr import treestr as t
-    >>> parts = [t("it was the best of times, it was the worst of times"),
-    ...     t("happy families are all alike"),
-    ...     t("once upon a time and a very good time it was")]
-    >>> first, second = sample(parts, 2)
-    >>> result = first[:randrange(len(first))] + second[randrange(len(second)):]
-    >>> print(result)
-    it was the best of times, it was families are all alike
-    >>> print(result.parents)
-    ('it was the best of times, it was ', 'families are all alike')
-    >>> print(result.parents[0].parents)
-    ('it was the best of times, it was the worst of times',)
-    >>> print(result.parents[1].parents)
-    ('happy families are all alike',)
+```python
+>>> from treestr import treestr as t
+>>> parts = [t("it was the best of times, it was the worst of times"),
+...     t("happy families are all alike"),
+...     t("once upon a time and a very good time it was")]
+>>> first, second = sample(parts, 2)
+>>> result = first[:randrange(len(first))] + second[randrange(len(second)):]
+>>> print(result)
+it was the best of times, it was families are all alike
+>>> print(result.parents)
+('it was the best of times, it was ', 'families are all alike')
+>>> print(result.parents[0].parents)
+('it was the best of times, it was the worst of times',)
+>>> print(result.parents[1].parents)
+('happy families are all alike',)
+```
 
 The `treestr` class is a subtype of `str`, but it adds an attribute `parents`
 that is a tuple of all of the strings that the string is derived from. You can
@@ -58,13 +64,15 @@ operators implemented with special methods like `__add__`, `__getitem__` and
 `__mod__`). If you manipulate the string using other methods, you can create a
 `treestr` object and set its parent manually:
 
-    >>> import re
-    >>> orig = "it was the best of times, it was the worst of times"
-    >>> repl = t(re.sub("times", "programs", orig), parents=(orig,))
-    >>> print(repl)
-    it was the best of programs, it was the worst of programs
-    >>> print(repl.parents)
-    ('it was the best of times, it was the worst of times',)
+```python
+>>> import re
+>>> orig = "it was the best of times, it was the worst of times"
+>>> repl = t(re.sub("times", "programs", orig), parents=(orig,))
+>>> print(repl)
+it was the best of programs, it was the worst of programs
+>>> print(repl.parents)
+('it was the best of times, it was the worst of times',)
+```
 
 ## Keeping track of tags
 
@@ -73,29 +81,33 @@ mechanism called `tags`. The `tags` attribute on a `treestr` is a Python
 `set()`; you can either set the tags using the `tags` parameter when
 initializing the object, or add tags using the regular `.add()` method:
 
-    >>> test = t("hi there", tags={'foo', 'bar'})
-    >>> print(test)
-    hi there
-    >>> print(test.tags)
-    {'foo', 'bar'}
-    >>> test.tags.add('baz')
-    >>> print(test.tags)
-    {'baz', 'foo', 'bar'}
+```python
+>>> test = t("hi there", tags={'foo', 'bar'})
+>>> print(test)
+hi there
+>>> print(test.tags)
+{'foo', 'bar'}
+>>> test.tags.add('baz')
+>>> print(test.tags)
+{'baz', 'foo', 'bar'}
+```
 
 The `.rtags()` method of a `treestr` object recursively constructs a set of
 tags for the given `treestr` object *and* the tags of all of its parents. This
 allows you to easily, e.g., get a list of authors whose work is included in
 your remixed string:
 
-    >>> parts = [t("it was the best of times, it was the worst of times", tags={'dickens'}),
-    ...     t("happy families are all alike", tags={'tolstoy'}),
-    ...     t("once upon a time and a very good time it was", tags={'joyce'})]
-    >>> first, second = sample(parts, 2)
-    >>> result = first[:randrange(len(first))] + second[randrange(len(second)):]
-    >>> print(result)
-    once upon a time and a very  best of times, it was the worst of times
-    >>> print(result.rtags())
-    {'joyce', 'dickens'}
+```python
+>>> parts = [t("it was the best of times, it was the worst of times", tags={'dickens'}),
+...     t("happy families are all alike", tags={'tolstoy'}),
+...     t("once upon a time and a very good time it was", tags={'joyce'})]
+>>> first, second = sample(parts, 2)
+>>> result = first[:randrange(len(first))] + second[randrange(len(second)):]
+>>> print(result)
+once upon a time and a very  best of times, it was the worst of times
+>>> print(result.rtags())
+{'joyce', 'dickens'}
+```
 
 Easy peasy, and if you're just using regular string methods, you don't have to
 change any of your code!
@@ -107,19 +119,23 @@ But be aware of `.join()`: if you want it to work properly, you need to call
 the `.join()` method of a `treestr` object (otherwise the result will be a
 regular `str`):
 
-    >>> result = t(' ').join([first[:5], second[-5:]])
-    >>> type(result)
-    <class 'treestr.treestr'>
-    >>> result.rtags()
-    {'joyce', 'dickens'}
-    >>> print(result)
-    once  times
+```python
+>>> result = t(' ').join([first[:5], second[-5:]])
+>>> type(result)
+<class 'treestr.treestr'>
+>>> result.rtags()
+{'joyce', 'dickens'}
+>>> print(result)
+once  times
+```
 
 ## Installation
 
 Install from Github with `pip` like so:
 
-    $ pip install git+https://github.com/aparrish/treestr#egg=treestr
+```bash
+$ pip install git+https://github.com/aparrish/treestr#egg=treestr
+```
 
 Not putting this on PyPI until I'm convinced it actually has utility for anyone
 other than me.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An over-engineered solution to an unimportant problem, by [Allison
 Parrish](http://www.decontextualize.com/)
 
 This is really raw software and it's probably not suitable for use by anyone
-other than me. I just wanted it on Github so I can include it in
+other than me. I just wanted it on GitHub so I can include it in
 `pip` requirements files.
 
 ## Motivation and examples
@@ -131,7 +131,7 @@ once  times
 
 ## Installation
 
-Install from Github with `pip` like so:
+Install from GitHub with `pip` like so:
 
 ```bash
 $ pip install git+https://github.com/aparrish/treestr#egg=treestr


### PR DESCRIPTION
GitHub have changed their Markdown implementation -- https://githubengineering.com/a-formal-spec-for-github-markdown/ -- so:

```
#Titles like this don't work
# Titles like this do work
```

#Titles like this don't work

# Titles like this do work

---

Also add syntax highlighting to README, fix a typo, and also test on Python 3.6.